### PR TITLE
Add Tooltip Components

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,33 +1,46 @@
-import React from 'react';
-import { LucideIcon } from 'lucide-react';
+import React from "react";
+import { LucideIcon } from "lucide-react";
+import { Tooltip } from "./Tooltip";
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'primary' | 'secondary';
+  variant?: "primary" | "secondary";
   icon?: LucideIcon;
   iconClassName?: string;
+  tooltip?: string;
+  tooltipLocation?: "top" | "bottom" | "left" | "right";
 }
 
-export function Button({ 
-  children, 
-  variant = 'primary', 
+export function Button({
+  children,
+  variant = "primary",
   icon: Icon,
-  iconClassName = '',
-  className = '',
-  ...props 
+  iconClassName = "",
+  className = "",
+  tooltip = "",
+  tooltipLocation = "top",
+  ...props
 }: ButtonProps) {
-  const baseStyles = 'px-8 py-3 rounded-lg font-semibold transition-colors flex items-center space-x-2';
+  const baseStyles =
+    "px-8 py-3 rounded-lg font-semibold transition-colors flex items-center space-x-2";
   const variants = {
-    primary: 'bg-blue-500 hover:bg-blue-600 text-white',
-    secondary: 'bg-white/10 hover:bg-white/20 text-white'
+    primary: "bg-blue-500 hover:bg-blue-600 text-white",
+    secondary: "bg-white/10 hover:bg-white/20 text-white",
   };
 
-  return (
-    <button 
+  const buttonContent = (
+    <button
       className={`${baseStyles} ${variants[variant]} ${className}`}
-      {...props}
-    >
-      {Icon && <Icon className={`h-5 w-5 ${iconClassName || ''}`} />}
+      {...props}>
+      {Icon && <Icon className={`h-5 w-5 ${iconClassName || ""}`} />}
       {children && <span>{children}</span>}
     </button>
+  );
+
+  return tooltip ? (
+    <Tooltip text={tooltip} position={tooltipLocation}>
+      {buttonContent}
+    </Tooltip>
+  ) : (
+    buttonContent
   );
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -7,7 +7,7 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   icon?: LucideIcon;
   iconClassName?: string;
   tooltip?: string;
-  tooltipLocation?: "top" | "bottom" | "left" | "right";
+  tooltipPosition?: "top" | "bottom" | "left" | "right";
 }
 
 export function Button({
@@ -17,7 +17,7 @@ export function Button({
   iconClassName = "",
   className = "",
   tooltip = "",
-  tooltipLocation = "top",
+  tooltipPosition = "top",
   ...props
 }: ButtonProps) {
   const baseStyles =
@@ -37,7 +37,7 @@ export function Button({
   );
 
   return tooltip ? (
-    <Tooltip text={tooltip} position={tooltipLocation}>
+    <Tooltip text={tooltip} position={tooltipPosition}>
       {buttonContent}
     </Tooltip>
   ) : (

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from "react";
+
+interface TooltipProps {
+  position: string;
+  text?: string;
+  children?: React.ReactNode;
+}
+
+export function Tooltip({
+  position = "top",
+  text = "",
+  children,
+}: TooltipProps) {
+  const [isVisible, setIsVisible] = useState(false);
+
+  // Define positioning classes for Tailwind CSS
+  const positionClasses = {
+    top: "bottom-full left-1/2 transform -translate-x-1/2 mb-2",
+    bottom: "top-full left-1/2 transform -translate-x-1/2 mt-2",
+    left: "right-full top-1/2 transform -translate-y-1/2 mr-2",
+    right: "left-full top-1/2 transform -translate-y-1/2 ml-2",
+  };
+
+  // Arrow positioning classes with bigger border width
+  const arrowClasses = {
+    top: "left-1/2 transform -translate-x-1/2 -bottom-3 border-t-8 border-t-gray-800",
+    bottom:
+      "left-1/2 transform -translate-x-1/2 -top-3 border-b-8 border-b-gray-800",
+    left: "top-1/2 transform -translate-y-1/2 -right-3 border-l-8 border-l-gray-800",
+    right:
+      "top-1/2 transform -translate-y-1/2 -left-3 border-r-8 border-r-gray-800",
+  };
+
+  return (
+    <div
+      className="relative inline-block"
+      onMouseEnter={() => setIsVisible(true)}
+      onMouseLeave={() => setIsVisible(false)}>
+      {children}
+      {isVisible && (
+        <div
+          role="tooltip"
+          className={`absolute z-10 p-2 text-sm text-white bg-gray-800 rounded shadow-lg ${positionClasses[position]} whitespace-nowrap transition-opacity duration-300 ease-in-out opacity-100`}>
+          {text}
+          <div
+            className={`absolute w-0 h-0 border-8 border-transparent ${arrowClasses[position]}`}></div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -35,7 +35,11 @@ export function Tooltip({
     <div
       className="relative inline-block"
       onMouseEnter={() => setIsVisible(true)}
-      onMouseLeave={() => setIsVisible(false)}>
+      onMouseLeave={() => setIsVisible(false)}
+      onFocus={() => setIsVisible(true)}
+      onBlur={() => setIsVisible(false)}
+      tabIndex={0} // Makes the element focusable
+      aria-describedby={isVisible ? "tooltip" : undefined}>
       {children}
       {isVisible && (
         <div

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -3,12 +3,14 @@ import React, { useState } from "react";
 interface TooltipProps {
   position?: "top" | "bottom" | "left" | "right";
   text?: string;
+  className?: string;
   children?: React.ReactNode;
 }
 
 export function Tooltip({
   position = "top",
   text = "",
+  className = "",
   children,
 }: TooltipProps) {
   const [isVisible, setIsVisible] = useState(false);
@@ -45,7 +47,7 @@ export function Tooltip({
         <div
           id="tooltip"
           role="tooltip"
-          className={`absolute z-10 p-2 text-sm text-white bg-gray-800 rounded shadow-lg ${positionClasses[position]} whitespace-nowrap transition-opacity duration-300 ease-in-out opacity-100`}
+          className={`absolute z-10 p-2 text-sm text-white bg-gray-800 rounded shadow-lg ${positionClasses[position]} whitespace-nowrap transition-opacity duration-300 ease-in-out opacity-100 ${className}`}
           aria-live="polite">
           {text}
           <div

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 
 interface TooltipProps {
-  position: string;
+  position?: "top" | "bottom" | "left" | "right";
   text?: string;
   children?: React.ReactNode;
 }

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -43,8 +43,10 @@ export function Tooltip({
       {children}
       {isVisible && (
         <div
+          id="tooltip"
           role="tooltip"
-          className={`absolute z-10 p-2 text-sm text-white bg-gray-800 rounded shadow-lg ${positionClasses[position]} whitespace-nowrap transition-opacity duration-300 ease-in-out opacity-100`}>
+          className={`absolute z-10 p-2 text-sm text-white bg-gray-800 rounded shadow-lg ${positionClasses[position]} whitespace-nowrap transition-opacity duration-300 ease-in-out opacity-100`}
+          aria-live="polite">
           {text}
           <div
             className={`absolute w-0 h-0 border-8 border-transparent ${arrowClasses[position]}`}></div>


### PR DESCRIPTION
Related to  #55 

Screenshot for the Tooltip:

<img width="416" alt="image" src="https://github.com/user-attachments/assets/28e41058-4756-4e60-8aae-d05d3a4cd94c">


## Task:
- [x] Create reusable tooltip component
/src/components/Tooltip.tsx
- [ ] Add tooltips to navigation items
- [x] Add tooltips to action buttons
Updated Button component to support "tooltip" and "tooltiplocation" props
- [x] Implement tooltip positioning
support "top" | "bottom" | "left" | "right" four positions.
- [x]  Add accessibility attributes
if any more accessibility attributes need to add, please let me know.

## Questions:

1. Concerning the navigation items, are they intended for the Nav Links (Pricing, Features, About, Contributions)? If so, would you prefer to use a tooltip to wrap them, like this:

`<Tooltip text="some text"><Link ....></Link></Tooltip>`

Or would you rather create a new Link component that supports tooltips?

2. I couldn't find the unit test project or test file at the moment, so I didn't include any unit tests. Should we add them?



