### PR TITLE
Issue #17 - Create pages 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,11 +10,14 @@ import { Contributors } from './pages/Contributors';
 import { Mission } from './pages/mission';
 import { Team } from './pages/team';
 import { Global } from './pages/global';
-
+import {PrivacyPolicy} from "./pages/privacy-policy.tsx";
+import {Contact} from "./pages/contact.tsx";
+import {TermsOfService} from "./pages/terms-of-service.tsx";
 import { NotFound } from './pages/404';
 
 import { LogIn } from './pages/logIn';
-import { SignUp } from './pages/signUp'; // Ensure correct import
+import { SignUp } from './pages/signUp';
+
 
 
 function App() {
@@ -30,6 +33,9 @@ function App() {
           <Route path="/team" element={<Team />} />
           <Route path="/global" element={<Global />} />
           <Route path="/about" element={<About />} />
+          <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+          <Route path="/contact" element={<Contact />} />
+          <Route path="/terms-of-service" element={<TermsOfService />} />
           <Route path="/login" element={<LogIn />} />
           <Route path="/signup" element={<SignUp />} /> {/* Ensure correct path */}
           <Route path="/contributors" element={<Contributors />} />

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,0 +1,81 @@
+import { TextArea } from './TextArea';
+import { Button } from './Button';
+
+export function ContactForm() {
+    return (
+        <div className="w-full max-w-xl mx-auto space-y-6 ">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                    <label className="block text-start text-sm font-medium text-gray-200 mb-2"
+                           htmlFor="firstName">
+                        First Name
+                    </label>
+                    <input
+                        type="text"
+                        id="firstName"
+                        name="firstName"
+                        autoComplete="none"
+                        required
+                        className="w-full bg-white/5 border border-gray-700 rounded-lg p-3 text-white placeholder-gray-400 focus:ring-blue-500 focus:border-transparent focus:outline-none focus:ring-2"
+                    />
+                </div>
+
+                <div>
+                    <label className="block text-start text-sm font-medium text-gray-200 mb-2"
+                           htmlFor="lastName">
+                        Last Name
+                    </label>
+                    <input
+                        type="text"
+                        id="lastName"
+                        name="lastName"
+                        autoComplete="none"
+                        required
+                        className="w-full bg-white/5 border border-gray-700 rounded-lg p-3 text-white placeholder-gray-400 focus:ring-blue-500 focus:border-transparent focus:outline-none focus:ring-2 "
+                    />
+                </div>
+            </div>
+
+            <div>
+                <label className="block text-start text-sm font-medium text-gray-200 mb-2"
+                       htmlFor="email">
+                    Email
+                </label>
+                <input
+                    type="email"
+                    id="email"
+                    name="email"
+                    autoComplete="none"
+                    required
+                    className="w-full bg-white/5 border border-gray-700 rounded-lg p-3 text-white placeholder-gray-400 focus:ring-blue-500 focus:border-transparent focus:outline-none focus:ring-2  "
+                />
+            </div>
+
+            <TextArea
+                label="How can we help you?"
+                name="message"
+                required
+                className="text-white"
+            />
+            <div className="flex items-center space-x-2">
+                <input
+                    type="checkbox"
+                    id="agree"
+                    name="agree"
+                    required
+                    className="h-4 w-4 text-blue-500 border-gray-700 rounded focus:ring-blue-500 focus:outline-none"
+                />
+                <label htmlFor="agree" className="text-sm text-gray-200">
+                    By selecting this, you agree to our <a href="/privacy-policy"
+                                                           className="text-blue-500 font-bold">privacy
+                    policy</a>.
+                </label>
+            </div>
+
+
+            <div>
+                <Button type="submit">Submit</Button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -29,7 +29,7 @@ export function Footer() {
                         </svg>
                         <div className="text-[#827EF8]">
                             <Link to="contributors"><h2 className="pb-2 hover:text-white">Contributors</h2></Link>
-                            <Link to="https://github.com/Swifty9/Maverick-AI"><h2 className="hover:text-white">Contact Us</h2></Link>
+                            <Link to="https://github.com/Swifty9/Maverick-AI"><h2 className="hover:text-white">GitHub</h2></Link>
                         </div>
                     </div>
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -17,7 +17,7 @@ export function Footer() {
                         </svg>
                         <div className="text-[#60A5FA]">
                             <Link to="about"><h2 className="pb-2 hover:text-white">About Us</h2></Link>
-                            <Link to="#"><h2 className="hover:text-white">Contact Us</h2></Link>
+                            <Link to="/contact"><h2 className="hover:text-white">Contact Us</h2></Link>
                         </div>
                     </div>
 
@@ -44,8 +44,8 @@ export function Footer() {
                             </g>
                         </svg>
                         <div className="text-[#A657F7]">
-                            <Link to="#"><h2 className="pb-2 hover:text-white">Privacy Policy</h2></Link>
-                            <Link to="#"><h2 className="hover:text-white">Terms of Service</h2></Link>
+                            <Link to="/privacy-policy"><h2 className="pb-2 hover:text-white">Privacy Policy</h2></Link>
+                            <Link to="/terms-of-service"><h2 className="hover:text-white">Terms of Service</h2></Link>
                         </div>
                     </div>
                 </div>

--- a/src/components/SectionData.tsx
+++ b/src/components/SectionData.tsx
@@ -1,0 +1,52 @@
+//To add a new section or modify existing ones:
+//1. Copy an existing section object.
+//2. Change the `id`, `title`, `description`, `details`, `icon`, and `color`.
+//3. Add it to the `sectionData` array.
+
+import { Database, Shield, FileText } from 'lucide-react';
+
+export const sectionData = [
+    {
+        id: 'dataCollection',
+        title: 'Data Collection',
+        description: 'We gather personal and non-personal data to enhance your experience. Learn more about the types of data collected.',
+        details: `
+          <ul class="list-disc pl-6">
+              <li><strong>Personal Data:</strong> Name, email address, phone number, payment details, etc.</li>
+              <li><strong>Non-Personal Data:</strong> Browser type, IP address, usage statistics, etc.</li>
+              <li><strong>Methods of Collection:</strong> Provided by users, collected via cookies, or received from third-party services.</li>
+          </ul>
+        `,
+        icon: Database,
+        color: 'text-blue-500', //change color as you need
+    },
+    {
+        id: 'yourRights',
+        title: 'Your Rights',
+        description: 'As a user, you have the right to access, modify, and delete your personal data. Contact us for assistance.',
+        details: `
+          <ul class="list-disc pl-6">
+              <li><strong>Right to Access:</strong> Request a copy of your data.</li>
+              <li><strong>Right to Rectification:</strong> Correct inaccurate or incomplete information.</li>
+              <li><strong>Right to Deletion:</strong> Under specific conditions, request deletion of your data.</li>
+              <li><strong>Right to Object:</strong> Object to processing for specific purposes, such as marketing.</li>
+          </ul>
+        `,
+        icon: Shield,
+        color: 'text-green-500', //change color as you need
+    },
+    {
+        id: 'thirdPartyServices',
+        title: 'Third-Party Services',
+        description: 'We may use third-party services to enhance your experience. Here\'s more information about them.',
+        details: `
+          <ul class="list-disc pl-6">
+              <li><strong>Google Analytics:</strong> To analyze user behavior and improve website functionality.</li>
+              <li><strong>Payment Processors:</strong> Securely handle payments via services like Stripe.</li>
+              <li><strong>Additional Services:</strong> Other integrations may be added over time to enhance user experience.</li>
+          </ul>
+        `,
+        icon: FileText,
+        color: 'text-red-500', //change color as you need
+    },
+];

--- a/src/components/TextArea.tsx
+++ b/src/components/TextArea.tsx
@@ -9,7 +9,7 @@ export function TextArea({ label, error, className = '', ...props }: TextAreaPro
   return (
     <div className="w-full">
       {label && (
-        <label className="block text-sm font-medium text-gray-200 mb-2">
+        <label className="block text-start text-sm font-medium text-gray-200 mb-2">
           {label}
         </label>
       )}

--- a/src/data/privacyPolicyData.tsx
+++ b/src/data/privacyPolicyData.tsx
@@ -5,7 +5,7 @@
 
 import { Database, Shield, FileText } from 'lucide-react';
 
-export const sectionData = [
+export const privacyPolicyData = [
     {
         id: 'dataCollection',
         title: 'Data Collection',

--- a/src/data/termsOfServiceData.tsx
+++ b/src/data/termsOfServiceData.tsx
@@ -1,0 +1,81 @@
+//To add a new section or modify existing ones:
+//1. Copy an existing section object.
+//2. Change the `id`, `title`, `description`, `details`, `icon`, and `color`.
+//3. Add it to the `sectionData` array.
+import { Shield, FileText, User} from 'lucide-react';
+
+export const termsOfServiceData = [
+
+    {
+        id: 'userRights',
+        title: 'User Rights and Responsibilities',
+        description: 'As a user, you have the right to use our services within the boundaries of the terms provided. You are also responsible for your actions while using our platform.',
+        details: `
+          <ul class="list-disc pl-6">
+              <li><strong>Rights:</strong> You have the right to access and use our services.</li>
+              <li><strong>Responsibilities:</strong> You agree not to engage in illegal activities or violate the rights of others.</li>
+          </ul>
+        `,
+        icon: User,
+        color: 'text-blue-500', //change color as you need
+    },
+    {
+        id: 'contentOwnership',
+        title: 'Content Ownership',
+        description: 'All content on the platform, including text, images, and videos, is owned by us or licensed to us. Users retain ownership of their uploaded content.',
+        details: `
+          <ul class="list-disc pl-6">
+              <li><strong>Ownership:</strong> We retain ownership of all site content unless stated otherwise.</li>
+              <li><strong>User-Generated Content:</strong> You retain ownership of content you upload, but grant us a license to use it.</li>
+          </ul>
+        `,
+        icon: FileText,
+        color: 'text-red-500', //change color as you need
+    },
+    {
+        id: 'limitations',
+        title: 'Limitation of Liability',
+        description: 'We are not liable for any damages arising from the use of our platform. Your use of the platform is at your own risk.',
+        details: `
+          <ul class="list-disc pl-6">
+              <li><strong>No Warranty:</strong> We make no warranties regarding the accuracy or reliability of the content.</li>
+              <li><strong>Limitation:</strong> Our liability is limited to the maximum extent permitted by law.</li>
+          </ul>
+        `,
+        icon: Shield,
+        color: 'text-yellow-500', //change color as you need
+    },
+    {
+        id: 'termination',
+        title: 'Termination of Account',
+        description: 'We reserve the right to suspend or terminate your account if you violate the terms or engage in prohibited activities.',
+        details: `
+          <ul class="list-disc pl-6">
+              <li><strong>Suspension:</strong> Accounts may be suspended for violating our terms.</li>
+              <li><strong>Termination:</strong> We can terminate accounts for severe violations or non-compliance.</li>
+          </ul>
+        `,
+        icon: Shield,
+        color: 'text-orange-500', //change color as you need
+    },
+    {
+        id: 'updates',
+        title: 'Changes to Terms of Service',
+        description: 'We may update our Terms of Service from time to time. Any changes will be communicated to you via our platform.',
+        details: `
+          <p>We reserve the right to update these terms at any time. Please review them periodically.</p>
+        `,
+        icon: FileText,
+        color: 'text-purple-500', //change color as you need
+    },
+    {
+        id: 'governingLaw',
+        title: 'Governing Law',
+        description: 'These terms are governed by the laws of the jurisdiction in which our company is based. Any disputes will be handled in the appropriate courts.',
+        details: `
+          <p>The laws of [Your Country] govern these terms and conditions.</p>
+        `,
+        icon: Shield,
+        color: 'text-indigo-500', //change color as you need
+    },
+];

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,0 +1,6 @@
+export function Contact() {
+    return (
+        <div>Hello World Contact</div>
+    );
+}
+

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,6 +1,32 @@
+import { motion } from "framer-motion";
+import { ContactForm } from "../components/ContactForm";
+
 export function Contact() {
+    const containerVariants = {
+        hidden: { opacity: 0, y: 50 },
+        visible: { opacity: 1, y: 0 },
+    };
+
     return (
-        <div>Hello World Contact</div>
+        <main className="container mx-auto px-6 py-20">
+            <div className="max-w-3xl mx-auto text-center">
+                <h1 className="text-5xl font-bold mb-6 bg-gradient-to-r from-red-400 to-yellow-500 text-transparent bg-clip-text">
+                   Get In Touch With Us
+                </h1>
+                <p className="text-xl text-gray-300 mb-12">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut
+                </p>
+            </div>
+
+            <motion.div
+                className="max-w-xl mx-auto bg-white/5 p-6 rounded-lg shadow-md"
+                variants={containerVariants}
+                initial="hidden"
+                animate="visible"
+                transition={{ duration: 0.5 }}
+            >
+                <ContactForm />
+            </motion.div>
+        </main>
     );
 }
-

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,5 +1,6 @@
 import { motion } from "framer-motion";
 import { ContactForm } from "../components/ContactForm";
+import {Footer} from "../components/Footer.tsx";
 
 export function Contact() {
     const containerVariants = {
@@ -27,6 +28,8 @@ export function Contact() {
             >
                 <ContactForm />
             </motion.div>
+            <Footer/>
         </main>
+
     );
 }

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -1,5 +1,72 @@
+import { motion } from 'framer-motion';
+import { useState } from 'react';
+import { sectionData } from '../components/sectionData';
+import { ChevronDown } from 'lucide-react'; // Für den Pfeil
+
 export function PrivacyPolicy() {
+    const [visibility, setVisibility] = useState<{ [key: string]: boolean }>(
+        Object.fromEntries(sectionData.map((section) => [section.id, false]))
+    );
+
+    const toggleVisibility = (sectionId: string) => {
+        setVisibility((prev) => ({
+            ...prev,
+            [sectionId]: !prev[sectionId],
+        }));
+    };
+
+    const sectionVariants = {
+        hidden: { opacity: 0, y: 20 },
+        visible: { opacity: 1, y: 0 },
+    };
+
     return (
-        <div>Hello World privacyPolicy</div>
+        <div className="container mx-auto px-6 py-20">
+            <div className="max-w-3xl mx-auto text-center">
+                <h1 className="text-5xl font-bold mb-6 bg-gradient-to-r from-green-400 to-blue-500 text-transparent bg-clip-text">
+                    Privacy Policy
+                </h1>
+                <p className="text-xl text-gray-300 mb-12">
+                    This Privacy Policy explains how we collect, use, and protect your information.
+                </p>
+            </div>
+
+            {sectionData.map((section) => (
+                <motion.div
+                    key={section.id}
+                    initial="hidden"
+                    animate="visible"
+                    transition={{ duration: 0.5 }}
+                    variants={sectionVariants}
+                    className="max-w-4xl mx-auto mt-8 bg-white/5 p-6 rounded-xl transition-transform transform hover:scale-102 hover:shadow-lg hover:bg-white/10 focus:scale-103 focus:shadow-lg cursor-pointer"
+                    onClick={() => toggleVisibility(section.id)}
+                >
+                    <div className="flex items-center justify-between mb-2">
+                        <div className="flex items-center">
+                            <div
+                                className="bg-blue-500/10 w-12 h-12 rounded-lg flex items-center justify-center mr-4">
+                                <section.icon className={`h-6 w-6 ${section.color}`} />
+                            </div>
+                            <h3 className="text-xl font-semibold">{section.title}</h3>
+                        </div>
+                        <ChevronDown
+                            className={`h-6 w-6 text-gray-400 transition-transform ${
+                                visibility[section.id] ? 'rotate-180' : ''
+                            }`}
+                        />
+                    </div>
+                    <p className="text-gray-400">{section.description}</p>
+
+                    {visibility[section.id] && (
+                        <div
+                            className="mt-4 text-gray-300"
+                            dangerouslySetInnerHTML={{ __html: section.details }}
+                        />
+                    )}
+                </motion.div>
+            ))}
+        </div>
     );
 }
+
+

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -1,0 +1,5 @@
+export function PrivacyPolicy() {
+    return (
+        <div>Hello World privacyPolicy</div>
+    );
+}

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -1,11 +1,11 @@
 import { motion } from 'framer-motion';
 import { useState } from 'react';
-import { sectionData } from '../components/sectionData';
+import { privacyPolicyData } from '../data/privacyPolicyData.tsx';
 import { ChevronDown } from 'lucide-react'; // Für den Pfeil
 
 export function PrivacyPolicy() {
     const [visibility, setVisibility] = useState<{ [key: string]: boolean }>(
-        Object.fromEntries(sectionData.map((section) => [section.id, false]))
+        Object.fromEntries(privacyPolicyData.map((section) => [section.id, false]))
     );
 
     const toggleVisibility = (sectionId: string) => {
@@ -31,7 +31,7 @@ export function PrivacyPolicy() {
                 </p>
             </div>
 
-            {sectionData.map((section) => (
+            {privacyPolicyData.map((section) => (
                 <motion.div
                     key={section.id}
                     initial="hidden"

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -1,7 +1,8 @@
 import { motion } from 'framer-motion';
 import { useState } from 'react';
 import { privacyPolicyData } from '../data/privacyPolicyData.tsx';
-import { ChevronDown } from 'lucide-react'; // Für den Pfeil
+import { ChevronDown } from 'lucide-react';
+import {Footer} from "../components/Footer.tsx"; // Für den Pfeil
 
 export function PrivacyPolicy() {
     const [visibility, setVisibility] = useState<{ [key: string]: boolean }>(
@@ -65,6 +66,7 @@ export function PrivacyPolicy() {
                     )}
                 </motion.div>
             ))}
+            <Footer/>
         </div>
     );
 }

--- a/src/pages/terms-of-service.tsx
+++ b/src/pages/terms-of-service.tsx
@@ -1,0 +1,6 @@
+export function TermsOfService() {
+    return (
+        <div>Hello world TermsOfService</div>
+    );
+}
+

--- a/src/pages/terms-of-service.tsx
+++ b/src/pages/terms-of-service.tsx
@@ -1,6 +1,75 @@
+import { motion } from 'framer-motion';
+import { useState } from 'react';
+import {termsOfServiceData} from "../data/termsOfServiceData.tsx";
+import { ChevronDown } from 'lucide-react';
+import {Footer} from "../components/Footer.tsx"; // Für den Pfeil
+
 export function TermsOfService() {
+    const [visibility, setVisibility] = useState<{ [key: string]: boolean }>(
+        Object.fromEntries(termsOfServiceData.map((section) => [section.id, false]))
+    );
+
+    const toggleVisibility = (sectionId: string) => {
+        setVisibility((prev) => ({
+            ...prev,
+            [sectionId]: !prev[sectionId],
+        }));
+    };
+
+    const sectionVariants = {
+        hidden: { opacity: 0, y: 20 },
+        visible: { opacity: 1, y: 0 },
+    };
+
     return (
-        <div>Hello world TermsOfService</div>
+        <div className="container mx-auto px-6 py-20">
+            <div className="max-w-3xl mx-auto text-center">
+                <h1 className="text-5xl font-bold mb-6 bg-gradient-to-r from-green-400 to-blue-500 text-transparent bg-clip-text">
+                    Terms of Service
+                </h1>
+                <p className="text-xl text-gray-300 mb-12">
+                    These Terms of Service govern your use of our website and services. By using our platform, you agree to comply with these terms.
+                </p>
+            </div>
+
+            {termsOfServiceData.map((section) => (
+                <motion.div
+                    key={section.id}
+                    initial="hidden"
+                    animate="visible"
+                    transition={{ duration: 0.5 }}
+                    variants={sectionVariants}
+                    className="max-w-4xl mx-auto mt-8 bg-white/5 p-6 rounded-xl transition-transform transform hover:scale-102 hover:shadow-lg hover:bg-white/10 focus:scale-103 focus:shadow-lg cursor-pointer"
+                    onClick={() => toggleVisibility(section.id)}
+                >
+                    <div className="flex items-center justify-between mb-2">
+                        <div className="flex items-center">
+                            <div
+                                className="bg-blue-500/10 w-12 h-12 rounded-lg flex items-center justify-center mr-4">
+                                <section.icon className={`h-6 w-6 ${section.color}`} />
+                            </div>
+                            <h3 className="text-xl font-semibold">{section.title}</h3>
+                        </div>
+                        <ChevronDown
+                            className={`h-6 w-6 text-gray-400 transition-transform ${
+                                visibility[section.id] ? 'rotate-180' : ''
+                            }`}
+                        />
+                    </div>
+                    <p className="text-gray-400">{section.description}</p>
+
+                    {visibility[section.id] && (
+                        <div
+                            className="mt-4 text-gray-300"
+                            dangerouslySetInnerHTML={{ __html: section.details }}
+                        />
+                    )}
+                </motion.div>
+            ))}
+            <Footer/>
+        </div>
+
     );
 }
+
 


### PR DESCRIPTION
- „Added Contact Us, Privacy Policy, and Terms of Service pages. 
- Created data components (privacyPolicyData, termsOfServiceData) for content structure, which can be easily modified. 
- The privacyPolicy and ToS are designed with sections to match the UI of the application, however it might be simpler to consider displaying them as PDF's directly on the page - let me know if you want this to be changed!
- Added form to ContactUs-Page - logic for submitting still needs to be implemented

<img width="933" alt="Bildschirmfoto 2024-11-26 um 15 23 40" src="https://github.com/user-attachments/assets/2833d40c-1593-4bf7-811a-a0c3e53858c8">
<img width="800" alt="Bildschirmfoto 2024-11-26 um 15 24 10" src="https://github.com/user-attachments/assets/3448e248-936d-4cf8-a011-7bb2c21d5889">
<img width="1273" alt="Bildschirmfoto 2024-11-26 um 15 24 23" src="https://github.com/user-attachments/assets/99924a59-a8d2-4c9f-a671-1be0b199500f">
