### PR TITLE
Add rulesets to prevent pushing of code from 'closed-source' branch to 'main' branch

### DIFF
--- a/.github/workflows/block-private-merge.yml
+++ b/.github/workflows/block-private-merge.yml
@@ -1,0 +1,17 @@
+name: Block Private Branch Merge to 'main' branch from 'closed-source' branch
+
+on:
+    pull_request:
+        branches:
+            - main # Target branch is main
+
+jobs:
+    block-private-merge:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check Source Branch
+              run: |
+                  if [[ "${{ github.head_ref }}" == "closed-source" ]]; then
+                    echo "Merge from closed-source branch is not allowed!"
+                    exit 1
+                  fi


### PR DESCRIPTION
### Changed made :-
- Create block-private-merge.yml 
- Add script to prevent code from being pushed into 'main' from 'closed-source' branch

### Context : 
`closed-source` is a private branch in Maverick AI repo which focuses towards implementing the backend and other core features which requires administrator access.